### PR TITLE
Added PONG responder

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -61,6 +61,10 @@ const TwitchBot = class TwitchBot extends EventEmitter {
   listen() {
     this.irc.on('data', data => {
       this.checkForError(data)
+      /* Twitch sends keep-alive PINGs, need to respond with PONGs */
+      if(data.includes('PING :tmi.twitch.tv')) {
+        this.irc.write('PONG :tmi.twitch.tv\r\n')
+      }
       if(data.includes('PRIVMSG')) {
         const chatter = parser.formatPRIVMSG(data)
         this.emit('message', chatter)


### PR DESCRIPTION
Twitch chat sends keep-alive `PING` messages. If the client doesn't respond with a corresponding `PONG` Twitch will drop the connection.